### PR TITLE
Add JS to SQL name mapping.

### DIFF
--- a/src/Database.ts
+++ b/src/Database.ts
@@ -168,7 +168,7 @@ class DatabaseImpl<T extends TableMap = {}> {
         throw new Error(`Cannot select zero columns.`);
       }
       const spec = pick<any, any>(tableOrSpec.$columns, ...keys);
-      return new SelectQueryBuilder(this.$, spec, false);
+      return new SelectQueryBuilder(this.$, spec, true);
     }
     return new SelectQueryBuilder(this.$, tableOrSpec, true);
   }

--- a/src/__tests__/integration/JoinTable.test.ts
+++ b/src/__tests__/integration/JoinTable.test.ts
@@ -6,18 +6,23 @@ afterEach(teardownPG);
 
 test("Join table", async () => {
   class UserCourses extends Table {
-    userid = new IntColumn();
-    courseid = new IntColumn();
+    userId = new IntColumn();
+    courseId = new IntColumn();
 
-    pkey = new PrimaryKeyConstraint(UserCourses, "userid", "courseid");
+    pkey = new PrimaryKeyConstraint(UserCourses, "userId", "courseId");
   }
 
   const pg = getPG();
   const db = Database(pg, { userCourses: new UserCourses() });
   await db.createTables();
 
-  await db.insertInto(db.userCourses).values({ userid: 1, courseid: 1 });
+  expect(db.userCourses.$tableName.sql).toBe("user_courses");
+  await db.insertInto(db.userCourses).values({ userId: 1, courseId: 1 });
+  expect(await db.selectOne(db.userCourses, "userId", "courseId")).toEqual({
+    userId: 1,
+    courseId: 1,
+  });
   expect(
-    db.insertInto(db.userCourses).values({ userid: 1, courseid: 1 }),
+    db.insertInto(db.userCourses).values({ userId: 1, courseId: 1 }),
   ).rejects.toThrow();
 });

--- a/src/__tests__/integration/Posts.test.ts
+++ b/src/__tests__/integration/Posts.test.ts
@@ -13,8 +13,12 @@ test("Integration test with users and posts", async () => {
     posts: new PostsTable(),
   });
 
+  expect(db.posts.$creationSQL()).toContain("creation_timestamp");
+  await db.createTables();
+
   const result = await db.select(db.users, "id", "name");
   assert<IsExact<(typeof result)[0], { id: number; name: string }>>(true);
+  expect(result).toEqual([]);
 
   await db.insertInto(db.users).values({
     name: "Travis",

--- a/src/__tests__/integration/tables.ts
+++ b/src/__tests__/integration/tables.ts
@@ -9,5 +9,7 @@ export class PostsTable extends Table {
   id = new SerialColumn();
   authorId = new IntColumn().references(UsersTable, "id");
   body = new TextColumn();
-  createdAt = new TimestampColumn().defaultCurrentTimestamp();
+  createdAt = new TimestampColumn()
+    .defaultCurrentTimestamp()
+    .sqlName("creation_timestamp");
 }

--- a/src/__tests__/tablesql.test.ts
+++ b/src/__tests__/tablesql.test.ts
@@ -5,6 +5,7 @@ import {
   createTableWrapper,
   Database,
   PrimaryKeyConstraint,
+  SerialColumn,
 } from "@";
 
 test("Table creation SQL is correct", () => {
@@ -37,7 +38,7 @@ test("Table creation SQL with references is correct", () => {
 
   const petsSQL = db.pets.$creationSQL();
   expect(petsSQL).toEqual(
-    expect.stringMatching(/ownerId INT .+ REFERENCES users\(id\)/i),
+    expect.stringMatching(/owner_id INT .+ REFERENCES users\(id\)/i),
   );
 });
 
@@ -53,4 +54,14 @@ test("Table creation SQL with primary key constraint is correct", () => {
 
   const sql = db.userCourses.$creationSQL();
   expect(sql).toContain("PRIMARY KEY (user, course)");
+});
+
+test("Table creation SQL with custom column names is correct", () => {
+  class Users extends Table {
+    id = new SerialColumn();
+    age = new IntColumn().sqlName("how_old_is_this_person");
+  }
+
+  const db = Database(null as any, { users: new Users() });
+  expect(db.users.$creationSQL()).toContain("how_old_is_this_person");
 });

--- a/src/constraints/PrimaryKeyConstraint.ts
+++ b/src/constraints/PrimaryKeyConstraint.ts
@@ -1,7 +1,7 @@
 import { Table, TableWrapper } from "@";
-import { PrimaryKey, SQLFragment } from "@/expr";
-import { Constraint } from "./Constraint";
+import { PrimaryKey } from "@/expr";
 import { ClassOf } from "@/utils";
+import { Constraint } from "./Constraint";
 
 /**
  * A primary key constraint on at least one column.
@@ -20,9 +20,9 @@ export class PrimaryKeyConstraint<T extends Table = Table> extends Constraint<
   }
 
   $creationExpr(tableWrapper: TableWrapper<string, T>) {
-    const columns = this.$columns
-      .map((column) => tableWrapper.$getColumnByName(column))
-      .map((columnWrapper) => new SQLFragment(columnWrapper.$columnName));
+    const columns = this.$columns.map(
+      (column) => tableWrapper.$getColumnWrapper(column).$columnName,
+    );
     return new PrimaryKey(columns);
   }
 }

--- a/src/expr/ColumnReference.ts
+++ b/src/expr/ColumnReference.ts
@@ -2,13 +2,17 @@ import { Expr } from "./Expr";
 import { ReductionContext } from "./ReductionContext";
 
 export class ColumnReference extends Expr<"column-reference"> {
-  constructor(public tableName: string, public columnName: string) {
+  constructor(
+    public tableName: Expr,
+    public columnName: Expr,
+    public forceQualified: boolean = false,
+  ) {
     super("column-reference");
   }
 
   toSQL(rc: ReductionContext): string {
-    return rc.qualifyNames()
-      ? this.tableName + "." + this.columnName
-      : this.columnName;
+    return this.forceQualified || rc.qualifyNames()
+      ? this.tableName.toSQL(rc) + "." + this.columnName.toSQL(rc)
+      : this.columnName.toSQL(rc);
   }
 }

--- a/src/expr/LTRTokens.ts
+++ b/src/expr/LTRTokens.ts
@@ -13,12 +13,15 @@ import { ReductionContext } from "./ReductionContext";
  * could model a WHERE clause as LTRTokens, we shouldn't.
  */
 export class LTRTokens extends Expr<"ltrtokens"> {
-  constructor(protected tokens: Array<Expr<string>> = []) {
+  constructor(
+    protected tokens: Array<Expr<string>> = [],
+    protected separator = " ",
+  ) {
     super("ltrtokens");
   }
 
   toSQL(rc: ReductionContext): string {
-    return this.tokens.map((token) => token.toSQL(rc)).join(" ");
+    return this.tokens.map((token) => token.toSQL(rc)).join(this.separator);
   }
 
   appendToken(...expr: Array<Expr<string>>) {

--- a/src/expr/SQLFragment.ts
+++ b/src/expr/SQLFragment.ts
@@ -15,6 +15,10 @@ export class SQLFragment extends Expr<"sqlfragment"> {
   toSQL(_context: ReductionContext): string {
     return this.sql;
   }
+
+  toString() {
+    return `sql\`${this.sql}\``;
+  }
 }
 
 export function isSQLFragment(s: unknown): s is SQLFragment {

--- a/src/querybuilders/InsertQueryBuilder.ts
+++ b/src/querybuilders/InsertQueryBuilder.ts
@@ -25,24 +25,20 @@ export class InsertQueryBuilder<
   DB extends Database<any>,
   TW extends TableWrapper<string, Table>
 > extends ExecutableQueryBuilder<DB, unknown> {
-  $tableName: SQLFragment;
+  $tableName: Expr;
   $columns?: SQLFragment[];
   $values?: Expr<string>[];
 
-  constructor(
-    db: DB,
-    $table: TW,
-    // $insertionSpec: Array<ColumnWrapper<string, unknown>>,
-  ) {
+  constructor(db: DB, public $table: TW) {
     super(db);
-    this.$tableName = new SQLFragment($table.$tableName);
+    this.$tableName = $table.$tableName;
   }
 
   values(spec: InsertInterface<TW>) {
     const columns = [] as this["$columns"];
     const values = [] as this["$values"];
     Object.entries(spec).forEach(([columnName, value]) => {
-      columns!.push(new SQLFragment(columnName));
+      columns!.push(this.$table.$getColumnWrapper(columnName).$columnName);
       values!.push(new Parameter(value));
     });
     this.$columns = columns;

--- a/src/querybuilders/SelectQueryBuilder.ts
+++ b/src/querybuilders/SelectQueryBuilder.ts
@@ -96,7 +96,7 @@ export class SelectQueryBuilder<
         column.$tableName,
         column.$columnName,
       );
-      if ($columnName != name) {
+      if ($columnName.sql != name) {
         // NOTE: we do quotes here to ensure that casing is correct in result
         // object.
         return new LTRTokens([
@@ -125,7 +125,7 @@ export class SelectQueryBuilder<
       this.$from = table;
       return this;
     } else if (isTableWrapper(table)) {
-      this.$from = new FromItem(new SQLFragment(table.$tableName));
+      this.$from = new FromItem(table.$tableName);
       return this;
     }
     throw new Error(
@@ -156,13 +156,13 @@ export class SelectQueryBuilder<
   }
 
   private $guessFromClause() {
-    let guess: string | null = null;
+    let guess: SQLFragment | null = null;
     for (const selector of Object.values(this.$selectorSpec)) {
       if (guess === null) {
         guess = selector.$tableName;
         continue;
       }
-      if (selector.$tableName !== guess) {
+      if (selector.$tableName.sql !== guess.sql) {
         throw new Error(
           `Unable to guess table name in query with columns from multiple ` +
             `tables; please set .from(table) on the query.`,
@@ -174,6 +174,6 @@ export class SelectQueryBuilder<
         `Cannot guess table name from query with no columns selected.`,
       );
     }
-    return new FromItem(new SQLFragment(guess));
+    return new FromItem(guess);
   }
 }

--- a/src/querybuilders/UpdateQueryBuilder.ts
+++ b/src/querybuilders/UpdateQueryBuilder.ts
@@ -74,7 +74,7 @@ export class UpdateQueryBuilder<
       );
     }
     return new Update({
-      tableName: new SQLFragment(this.$table.$tableName),
+      tableName: this.$table.$tableName,
       updates: this.$updates,
       where: this.$where,
     });

--- a/src/utils/__tests__/sanitization.test.ts
+++ b/src/utils/__tests__/sanitization.test.ts
@@ -1,0 +1,21 @@
+import {
+  assertSQLSafeIdentifier,
+  camel2snake,
+  isSQLSafeIdentifier,
+} from "../identifiers";
+
+test("isSQLSafeIdentifier", () => {
+  expect(isSQLSafeIdentifier("userId")).toBe(true);
+  expect(isSQLSafeIdentifier("user_id")).toBe(true);
+  expect(isSQLSafeIdentifier("user-id")).toBe(false);
+});
+
+test("assertSQLSafeIdentifier", () => {
+  expect(() => assertSQLSafeIdentifier("'foo'")).toThrow();
+  expect(() => assertSQLSafeIdentifier("user_id")).not.toThrow();
+});
+
+test("camel2snake", () => {
+  expect(camel2snake("userId")).toBe("user_id");
+  expect(camel2snake("userID")).toBe("user_id");
+});

--- a/src/utils/identifiers.ts
+++ b/src/utils/identifiers.ts
@@ -1,0 +1,27 @@
+const ALPHANUMERIC_REGEX = /^[A-Za-z_]+$/;
+
+/**
+ * Returns true if the identifier is safe for SQL.
+ *
+ * We don't use parameters for things like column names etc., and they
+ *  technically
+ */
+export function isSQLSafeIdentifier(identifier: string): boolean {
+  return !!identifier.match(ALPHANUMERIC_REGEX);
+}
+
+export function assertSQLSafeIdentifier(identifier: string) {
+  if (!isSQLSafeIdentifier(identifier)) {
+    throw new Error(`Invalid (unsafe) SQL identifier: ${identifier}`);
+  }
+  return identifier;
+}
+
+/**
+ * Convert a camel-case string into a snake-case string.
+ */
+export function camel2snake(identifier: string): string {
+  return identifier
+    .replace(/([a-z][A-Z])/, (s, c) => c[0].toLowerCase() + "_" + c[1])
+    .toLowerCase();
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./UndefinedOptional";
 export * from "./classes";
 export * from "./debug";
 export * from "./iama";
+export * from "./identifiers";
 export * from "./getters";
 export * from "./pick";
 export * from "./typeguards";


### PR DESCRIPTION
Closes #11.

Maps column names like `userId` (which is idiomatic JS) to `user_id` (which is idiomatic SQL).